### PR TITLE
turn off rust caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,22 +63,12 @@ jobs:
 
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu'
-
     - uses: stairwell-inc/checkout@v4
-    - uses: stairwell-inc/cache@v4
-      with:
-        path: |
-          ~/.cargo
-          target
-        key: rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
-          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-
-          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-
     - run: rustup toolchain install ${{ env.RUSTC_VERSION }} --target ${{ env.target }} --profile minimal
     - run: rustup default ${{ env.RUSTC_VERSION }}
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}
+
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ env.target }}


### PR DESCRIPTION
incredibly, fastbuild seems faster than saving and restoring the cache, even on Windows.